### PR TITLE
Update server build fileName from production to node-build

### DIFF
--- a/vite.config.server.ts
+++ b/vite.config.server.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, "server/node-build.ts"),
       name: "server",
-      fileName: "production",
+      fileName: "node-build",
       formats: ["es"],
     },
     outDir: "dist/server",


### PR DESCRIPTION
## Changes Made

Updated the Vite server configuration to change the output filename for the server build.

### Modified Files
- `vite.config.server.ts`

### Specific Changes
- Changed `fileName` property from `"production"` to `"node-build"` in the library configuration
- This affects the output filename of the server build bundleTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d779799602984c07ad8609b5bfb05ad8/curry-nest)

👀 [Preview Link](https://d779799602984c07ad8609b5bfb05ad8-curry-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d779799602984c07ad8609b5bfb05ad8</projectId>-->
<!--<branchName>curry-nest</branchName>-->